### PR TITLE
docs: fix simple typo, teqhniques -> techniques

### DIFF
--- a/Chapter 26 Indexing Multiple Vertex Arrays/external/glfw-2.7/examples/particles.c
+++ b/Chapter 26 Indexing Multiple Vertex Arrays/external/glfw-2.7/examples/particles.c
@@ -4,7 +4,7 @@
 // projected on simple geometry).
 //
 // This demonstration generates a colorful fountain-like animation. It
-// uses several advanced OpenGL teqhniques:
+// uses several advanced OpenGL techniques:
 //
 //  1) Lighting (per vertex)
 //  2) Alpha blending


### PR DESCRIPTION
There is a small typo in Chapter 26 Indexing Multiple Vertex Arrays/external/glfw-2.7/examples/particles.c.

Should read `techniques` rather than `teqhniques`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md